### PR TITLE
Set isBmissing explicitly to kBjet_Missing if no b-jets available

### DIFF
--- a/src/MultiLepton.cpp
+++ b/src/MultiLepton.cpp
@@ -1412,6 +1412,10 @@ void MultiLepton::SetPresenceBandJets(MEPhaseSpace** meIntegrator, int KindTwoTo
        (*meIntegrator)->MEMFix_TopLep.isBmissing = kBjet_Present;
      }
    }
+   if (Bjets.size()==0){
+       (*meIntegrator)->MEMFix_TopHad.isBmissing = kBjet_Missing;
+       (*meIntegrator)->MEMFix_TopLep.isBmissing = kBjet_Missing;
+   }
  }
  if (KindTwoTops==1){ //Top lep, top lep
    if (Bjets.size()==2){
@@ -1427,6 +1431,10 @@ void MultiLepton::SetPresenceBandJets(MEPhaseSpace** meIntegrator, int KindTwoTo
        (*meIntegrator)->MEMFix_TopLep.isBmissing = kBjet_Missing;
        (*meIntegrator)->MEMFix_TopLep2.isBmissing = kBjet_Present;
      }
+   }
+   if (Bjets.size()==0){
+       (*meIntegrator)->MEMFix_TopLep.isBmissing = kBjet_Missing;
+       (*meIntegrator)->MEMFix_TopLep2.isBmissing = kBjet_Missing;
    }
  }
  if (KindTwoTops==-1){ //top lep, no 2nd top


### PR DESCRIPTION
Two technicalities:
- `isBmissing` defaults to 0 if it's not explicitly given some other value;
- `kBjet_Present` is defined as 0.

So, if the b-jet multiplicity is not explicitly checked in `MultiLepton::SetPresenceBandJets`, then it automatically means that `isBmissing` is `kBjet_Present` for both top legs. This caused runtime errors when running ttH semileptonic hypothesis on an event that had no b-jets passing the loose b-tagging CSV WPs.

PS. For future reference, use `enum class` instead of plain `#define`.